### PR TITLE
Data(standardization): LoadBeard, LoadHair, LoadTeeth

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -570,7 +570,7 @@ function ConvertCacheToHash(ClothesCache)
                     else
                         list = clothing[IsPedMale(PlayerPedId()) and "male" or "female"][k]
                     end
-                    if list?[id]?[tonumber(v.texture)] then
+                    if list and list[id] and list[id][tonumber(v.texture)] then -- Not sure why the question marks where in here, it was throwing some weird alerts.
                         clothesHashes[k] = { hash = tonumber(list[id][tonumber(v.texture)].hash) }
                     end
                 end
@@ -582,9 +582,11 @@ function ConvertCacheToHash(ClothesCache)
         else
             clothesHashes[k] = v
         end
-    end
-    return clothesHashes
+    end --03/23/2025: Missing `end` for the `for` loop
+
+    return clothesHashes -- Properly moved outside the loop
 end
+
 
 function GetGender()
     if not IsPedMale(PlayerPedId()) then
@@ -827,6 +829,7 @@ function LoadHair(target, data)
                     if hairs_list["male"]["hair"][tonumber(data.hair.model)] ~= nil then
                         if hairs_list["male"]["hair"][tonumber(data.hair.model)][tonumber(data.hair.texture)] ~= nil then
                             local hair = hairs_list["male"]["hair"][tonumber(data.hair.model)][tonumber(data.hair.texture)].hash
+                            data.hair.hash = hair
                             NativeSetPedComponentEnabled(target, tonumber(hair), false, true, true)
                         end
                     end
@@ -835,6 +838,7 @@ function LoadHair(target, data)
                         if hairs_list["female"]["hair"][tonumber(data.hair.model)][tonumber(data.hair.texture)] ~=
                             nil then
                             local hair = hairs_list["female"]["hair"][tonumber(data.hair.model)][tonumber(data.hair.texture)].hash
+                            data.hair.hash = hair
                             NativeSetPedComponentEnabled(target, tonumber(hair), false, true, true)
                         end
                     end
@@ -854,6 +858,7 @@ function LoadHair(target, data)
     end
 end
 
+
 function LoadBeard(target, data)
     if data.beard ~= nil then
         if type(data.beard) ~= "table" then data.beard = { hash = data.beard } end
@@ -864,6 +869,7 @@ function LoadBeard(target, data)
                         if hairs_list["male"]["beard"][tonumber(data.beard.model)][tonumber(data.beard.texture)] ~=
                             nil then
                             local beard = hairs_list["male"]["beard"][tonumber(data.beard.model)][tonumber(data.beard.texture)].hash
+                            data.beard.hash = beard
                             NativeSetPedComponentEnabled(target, tonumber(beard), false, true, true)
                         end
                     end
@@ -903,6 +909,26 @@ end
 function LoadBodyFeature(target, data, bodyFeatureTable)
     Citizen.InvokeNative(0x1902C4CFCC5BE57C, target, bodyFeatureTable[tonumber(data)])
     Citizen.InvokeNative(0xCC8CA3E88256E58F, target, false, true, true, true, false)
+end
+
+function LoadTeeth(target, data) -- There's a chance that this probably will get over-ridden by LoadFeatures, but realistically the entire point of this is to update data.teeth to store the hash anyway.
+    local animf = {"mouth_looted","face_human@gen_male_timid@base"}
+    RequestAnimDict(animf[2])
+    while not HasAnimDictLoaded(animf[2]) do 
+        Wait(1)
+    end
+    local a = "male"
+    if not IsPedMale(target) then 
+        a = "female"
+    end
+    local b = GetHashKey(TEETH_TYPES[a]..(data.teeth or 0))
+    data.teeth = b
+    NativeSetPedComponentEnabled(target, b, true, true, true)
+    NativeUpdatePedVariation(target)
+    SetFacialIdleAnimOverride(target, animf[2], animf[1])
+    SetTimeout(2000, function()
+        ClearFacialIdleAnimOverride(target)
+    end)
 end
 
 function LoadFeatures(target, data)

--- a/server/sv_appearance.lua
+++ b/server/sv_appearance.lua
@@ -1,5 +1,50 @@
 RSGCore = exports['rsg-core']:GetCoreObject()
 
+-- Begin conversion commands & events
+-- These three commands &  events are to convert beards, hair & teeth indexes in your database into hashes. Remove them & their accompanying client events if you do not intend to convert them. They are optional and exist only to make other creators lives a little easier when making character creation scripts.
+RegisterCommand("fixOldBeards", function(src, args, raw)
+    MySQL.query("SELECT * FROM skins", {}, function(results)
+        TriggerClientEvent("fixOldBeards:doConversion", src, results)
+    end)
+end)
+
+RegisterNetEvent("fixOldBeards:saveConverted")
+AddEventHandler("fixOldBeards:saveConverted", function(updates)
+    for _, record in ipairs(updates) do
+        MySQL.update("UPDATE skins SET skin = ? WHERE id = ?", { record.json, record.id })
+    end
+    print("Fix Old Beards Complete")
+end)
+
+RegisterCommand("fixOldHair", function(src, args, raw)
+    MySQL.query("SELECT * FROM skins", {}, function(results)
+        TriggerClientEvent("fixOldHair:doConversion", src, results)
+    end)
+end)
+
+RegisterNetEvent("fixOldHair:saveConverted")
+AddEventHandler("fixOldHair:saveConverted", function(updates)
+    for _, record in ipairs(updates) do
+        MySQL.update("UPDATE skins SET skin = ? WHERE id = ?", { record.json, record.id })
+    end
+    print("Fix Old Hair Complete")
+end)
+
+RegisterCommand("fixOldTeeth", function(src, args, raw)
+    MySQL.query("SELECT * FROM skins", {}, function(results)
+        TriggerClientEvent("fixOldTeeth:doConversion", src, results)
+    end)
+end)
+
+RegisterNetEvent("fixOldTeeth:saveConverted")
+AddEventHandler("fixOldTeeth:saveConverted", function(updates)
+    for _, record in ipairs(updates) do
+        MySQL.update("UPDATE skins SET skin = ? WHERE id = ?", { record.json, record.id })
+    end
+    print("Fix Old Teeth Complete")
+end)
+-- End Conversion Commands
+
 RegisterServerEvent('rsg-appearance:server:SaveSkin')
 AddEventHandler('rsg-appearance:server:SaveSkin', function(skin, clothes, oldplayer)
     local encode = json.encode(skin)


### PR DESCRIPTION
- Update LoadHair, Loadbeard to directly save the hash instead of index pairs. Maintains usability from the index pairs for legacy data.
- Adds conversion commands for hair, beard & teeth data (read the desc of the [commit ](https://github.com/RedEM-RP/redemrp_creator/commit/d4501c0ec97206ae70d85a101ed3f9ed5c2bf92c)for details)
- Add LoadTeeth (credit to @zelbeus), note: may not integrate properly due to LoadFeatures but really we're just trying to update data.teeth anyway.