### PR TITLE
state for cloth shop, loadskin to reapply dirt

### DIFF
--- a/client/clothes.lua
+++ b/client/clothes.lua
@@ -6,15 +6,15 @@ local Outfits_tab = {}
 local CurrentPrice = 0
 local CurentCoords = {}
 local playerHeading = nil
-local inClothingStore = false
 local RoomPrompts = GetRandomIntInRange(0, 0xffffff)
 local Divider = "<img style='margin-top: 10px;margin-bottom: 10px; margin-left: -10px;'src='nui://rsg-appearance/img/divider_line.png'>"
 local image = "<img style='max-height:250px;max-width:250px;float: center;'src='nui://rsg-appearance/img/%s.png'>"
 
 local clothing = require 'data.clothing'
 
+---@deprecated use inClothingStore state
 exports('IsCothingActive', function()
-    return inClothingStore
+    return LocalPlayer.state.inClothingStore
 end)
 
 CreateThread(function()
@@ -350,13 +350,13 @@ function TeleportAndFade(coords4, resetCoords)
     Wait(1000)
     Citizen.InvokeNative(0x203BEFFDBE12E96A, PlayerPedId(), coords4)
     SetEntityCoordsNoOffset(PlayerPedId(), coords4, true, true, true)
-    inClothingStore = true
+    LocalPlayer.state.inClothingStore = true
     Wait(1500)
     DoScreenFadeIn(1800)
     if resetCoords then
         CurentCoords = {}
         TogglePrompts({ "TURN_LR", "CAM_UD", "ZOOM_IO" }, false)
-        inClothingStore = false
+        LocalPlayer.state.inClothingStore = false
         TriggerServerEvent('rsg-appearance:server:SetPlayerBucket', 0)
     end
 end
@@ -552,6 +552,7 @@ function GenerateMenu()
 end
 
 CreateThread(function()
+    LocalPlayer.state.inClothingStore = false
     CreateBlips()
     if RegisterPrompts() then
         local room = false
@@ -663,6 +664,7 @@ end
 
 AddEventHandler('onResourceStop', function(resourceName)
     if GetCurrentResourceName() ~= resourceName then return end
+    LocalPlayer.state.inClothingStore = false
     destory()
     for i=1, #RSG.CreatedEntries do
         if RSG.CreatedEntries[i].type == "BLIP" then

--- a/client/creator.lua
+++ b/client/creator.lua
@@ -199,6 +199,9 @@ function ApplySkin()
     local citizenid = RSGCore.Functions.GetPlayerData().citizenid
     local PlayerData = RSGCore.Functions.GetPlayerData()
     local currentHealth = PlayerData.metadata["health"]
+    local dirtClothes = GetAttributeBaseRank(_Target, 16)
+    local dirtHat = GetAttributeBaseRank(_Target, 17)
+    local dirtSkin = GetAttributeBaseRank(_Target, 22)
 
     local promise = promise.new()
     RSGCore.Functions.TriggerCallback('rsg-multicharacter:server:getAppearance', function(data)
@@ -237,6 +240,9 @@ function ApplySkin()
                 { name = m.name, visibility = 0, tx_id = 1, tx_normal = 0, tx_material = 0, tx_color_type = 0, tx_opacity = 1.0, tx_unk = 0, palette = 0, palette_color_primary = 0, palette_color_secondary = 0, palette_color_tertiary = 0, var = 0, opacity = 0.0 }
             end
         end
+        SetAttributeBaseRank(_Target, 16, dirtClothes)
+        SetAttributeBaseRank(_Target, 17, dirtHat)
+        SetAttributeBaseRank(_Target, 22, dirtSkin)
         promise:resolve()
     end, citizenid)
     Citizen.Await(promise)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ game 'rdr3'
 lua54 'yes'
 
 description 'rsg-appearance'
-version '2.4.5'
+version '2.4.6'
 
 shared_scripts {
     '@ox_lib/init.lua',


### PR DESCRIPTION
- added `LocalPlayer.state.inClothingStore` state to easier integration with other resources
- loadskin now remembers dirt levels so it can't be used as free cleaning alternative