### PR TITLE
fix wardrobe clothes handling

### DIFF
--- a/client/clothes.lua
+++ b/client/clothes.lua
@@ -417,11 +417,10 @@ function Outfits()
     MenuData.CloseAll()
     local Result = lib.callback.await('rsg-appearance:server:getOutfits', false)
     local elements_outfits = {}
-    local name
     for k, v in pairs(Result) do
-        name = v.name
         elements_outfits[#elements_outfits + 1] = {
-            label = '#' .. k .. '. ' .. name,
+            name = v.name,
+            label = '#' .. k .. '. ' .. v.name,
             value = v.clothes,
             desc = RSG.Label.choose
         }
@@ -429,7 +428,7 @@ function Outfits()
     MenuData.Open('default', GetCurrentResourceName(), 'outfits_menu',
         {title = RSG.Label.clothes, subtext = RSG.Label.choose, align = 'top-left', elements = elements_outfits, itemHeight = "4vh"},
         function(data, menu)
-            OutfitsManage(data.current.value, name)
+            OutfitsManage(data.current.value, data.current.name)
         end, function(data, menu)
             menu.close()
         end)


### PR DESCRIPTION
Fix deleting the wrong outfit when player uses the Cloak Room / Changing Room.

Error simulated:
As can be seen in the prints, it passed the wrong outfit name value for players to wear or delete
https://medal.tv/games/red-dead-2/clips/lc66lpSHV-0Gr2_Y6?invite=cr-MSxOalosMzQ3MzIwMzMw&v=16

Fix:
Prints stated that the correct outfit name value is used for players to wear or passed to the serverside to be deleted from database.
https://medal.tv/games/red-dead-2/clips/lccNe9G3sS4-d59bk?invite=cr-MSx1Vk8sMzQ3MzIwMzMw&v=15

<img width="599" height="25" alt="image" src="https://github.com/user-attachments/assets/a7946045-9fce-47b8-89a1-c4da57095272" />